### PR TITLE
Update README.md to use last version of gpb that builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add exprotobuf as a dependency to your project:
 ```elixir
 defp deps do
   [{:exprotobuf, "~> 0.8.5"},
-   {:gpb, github: "tomas-abrahamsson/gpb"}]
+   {:gpb, github: "tomas-abrahamsson/gpb", tag: "3.17.2"}]
 end
 ```
 


### PR DESCRIPTION
I had to use this tag, tag after this one. They removed the post_process function in place of "process all files" and "process one file". I was too lazy to update the whole repo as I don't FULLY understand protocolbufs but this lets it build!