### PR TITLE
Infinite loop upon encode/1 with inject: true

### DIFF
--- a/lib/exprotobuf.ex
+++ b/lib/exprotobuf.ex
@@ -13,6 +13,9 @@ defmodule Protobuf do
         %Config{namespace: namespace, schema: schema}
       [<< schema :: binary >>, only: only] ->
         %Config{namespace: namespace, schema: schema, only: parse_only(only, __CALLER__)}
+      [<< schema :: binary >>, inject: true] ->
+        only = namespace |> Module.split |> Enum.join(".") |> String.to_atom
+        %Config{namespace: namespace, schema: schema, only: [only], inject: true}
       [<< schema :: binary >>, only: only, inject: true] ->
         types = parse_only(only, __CALLER__)
         case types do
@@ -23,6 +26,8 @@ defmodule Protobuf do
         %Config{namespace: namespace, schema: read_file(file, __CALLER__)}
       [from: file, only: only] ->
         %Config{namespace: namespace, schema: read_file(file, __CALLER__), only: parse_only(only, __CALLER__)}
+      [from: file, inject: true] ->
+        %Config{namespace: namespace, schema: read_file(file, __CALLER__), only: [namespace], inject: true}
       [from: file, only: only, inject: true] ->
         types = parse_only(only, __CALLER__)
         case types do

--- a/lib/exprotobuf/builder.ex
+++ b/lib/exprotobuf/builder.ex
@@ -74,15 +74,11 @@ defmodule Protobuf.Builder do
     end
 
     # Global defs helper
-    if inject do
-      quotes
-    else
-      quotes ++ [quote do
-        def defs do
-          unquote(Macro.escape(msgs, unquote: true))
-        end
-      end]
-    end
+    quotes ++ [quote do
+      def defs do
+        unquote(Macro.escape(msgs, unquote: true))
+      end
+    end]
   end
 
   defp is_child_type?(child, type) do

--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -52,9 +52,9 @@ defmodule Protobuf.DefineMessage do
 
   defp constructors(name) do
     quote location: :keep do
-      def new(), do: %unquote(name){}
+      def new(), do: struct(unquote(name))
       def new(values) when is_list(values) do
-        Enum.reduce(values, %unquote(name){}, fn
+        Enum.reduce(values, new, fn
           {key, value}, obj ->
             if Map.has_key?(obj, key) do
               Map.put(obj, key, value)
@@ -84,9 +84,10 @@ defmodule Protobuf.DefineMessage do
 
   defp meta_information do
     quote do
-      def defs(_ \\ nil),         do: @root.defs
+      def defs,                   do: @root.defs
       def defs(:field, _),        do: nil
       def defs(:field, field, _), do: defs(:field, field)
+      defoverridable [defs: 0]
     end
   end
 

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -19,11 +19,15 @@ defmodule ProtobufTest do
   end
 
   test "define records in namespace with injection" do
-    mod = def_proto_module ["
-       message Msg1 {
-         required uint32 f1 = 1;
+    contents = quote do
+      use Protobuf, ["
+       message InjectionTest {
+           required uint32 f1 = 1;
        }
-    ", only: :Msg1, inject: true]
+      ", inject: true]
+    end
+
+    {:module, mod, _, _} = Module.create(InjectionTest, contents, Macro.Env.location(__ENV__))
 
     assert %{:__struct__ => ^mod, :f1 => 1} = mod.new(f1: 1)
   end

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -18,6 +18,16 @@ defmodule ProtobufTest do
     assert %{:__struct__ => ^msg2, :f1 => "foo"} = mod.Msg2.new(f1: "foo")
   end
 
+  test "define records in namespace with injection" do
+    mod = def_proto_module ["
+       message Msg1 {
+         required uint32 f1 = 1;
+       }
+    ", only: :Msg1, inject: true]
+
+    assert %{:__struct__ => ^mod, :f1 => 1} = mod.new(f1: 1)
+  end
+
   test "set default value for nil is optional" do
     mod = def_proto_module "message Msg { optional uint32 f1 = 1; }"
     msg = mod.Msg.new()


### PR DESCRIPTION
When using the `inject` option, it looks like the `defs` function (https://github.com/bitwalker/exprotobuf/blob/master/lib/exprotobuf/define_message.ex#L87 ) loops infinitely. `encode/1` calls `defs` (as an argument to `Encoder.encode/2`), `defs(_ \\ nil)` responds and calls `@root.defs` (itself)

Should injected modules also get the global defs helper from https://github.com/bitwalker/exprotobuf/blob/master/lib/exprotobuf/builder.ex#L77?

Test case below:

```elixir
defmodule Basic do
  use Protobuf, from: Path.expand("../test/proto/basic.proto", __DIR__), only: :Basic, inject: true
end
```

```
Interactive Elixir (1.0.3) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Basic.new
%Basic{args: nil, f1: nil, f2: nil, type: nil}
iex(2)> Basic.new |> Basic.encode

BREAK: (a)bort (c)ontinue (p)roc info (i)nfo (l)oaded
       (v)ersion (k)ill (D)b-tables (d)istribution
^C%
```