### PR TITLE
Expose enum atoms and values through atoms/0 and values/0 functions

### DIFF
--- a/lib/exprotobuf/define_enum.ex
+++ b/lib/exprotobuf/define_enum.ex
@@ -6,10 +6,14 @@ defmodule Protobuf.DefineEnum do
   getting either the name or value of an enumeration value.
   """
   def def_enum(name, values, inject: inject) do
+    enum_atoms = Enum.map values, fn {a, _} -> a end
+    enum_values = Enum.map values, fn {_, v} -> v end
     contents = for {atom, value} <- values do
       quote do
         def value(unquote(atom)), do: unquote(value)
+        def values(), do: unquote(enum_values)
         def atom(unquote(value)), do: unquote(atom)
+        def atoms(), do: unquote(enum_atoms)
       end
     end
     if inject do

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -76,6 +76,12 @@ defmodule ProtobufTest do
 
     assert nil == mod.Version.atom(-1)
     assert nil == mod.Msg.MsgType.value(:OTHER)
+
+    assert [:V0_1, :V0_2] == mod.Version.atoms
+    assert [:START, :STOP] == mod.Msg.MsgType.atoms
+
+    assert [1, 2] == mod.Version.values
+    assert [1, 2] == mod.Msg.MsgType.values
   end
 
   test "support define from a file" do


### PR DESCRIPTION
In a project of mine, I have an use case where I'm converting CSV data into protobuf messages. To validate that the CSV data has an row for each Enum value, I needed to expose valid atoms and values for an generated enum module.