### PR TITLE
Fix compile error trying to extract ?gpb_field record from gpb.hrl

### DIFF
--- a/lib/exprotobuf/field.ex
+++ b/lib/exprotobuf/field.ex
@@ -1,5 +1,5 @@
 defmodule Protobuf.Field do
-  @record Record.Extractor.extract(:"?gpb_field", from: Path.join([Mix.Project.deps_path, "gpb", "include", "gpb.hrl"]))
+  @record Record.Extractor.extract(:field, from: Path.join([Mix.Project.deps_path, "gpb", "include", "gpb.hrl"]))
   defstruct @record
 
   def record, do: @record


### PR DESCRIPTION
During mix.compile stage the exprotobuf library failed to compile with the following error:

(dev) ➜  ~/s/exprotobuf git:(master) ✗ mix compile
Compiled lib/exprotobuf/encoder.ex
Compiled lib/exprotobuf/utils.ex

== Compilation error on file lib/exprotobuf/field.ex ==
** (ArgumentError) no record ?gpb_field found at /Users/janneka/src/exprotobuf/deps/gpb/include/gpb.hrl
    (elixir) lib/record/extractor.ex:38: Record.Extractor.extract_record/2
    lib/exprotobuf/field.ex:2: (module)
    (stdlib) erl_eval.erl:657: :erl_eval.do_apply/6

Seems like using :field instead of :"?gdb_field" works and project compiles.
