### PR TITLE
Added support for Protobuf Extensions to the encoder and decoder

### DIFF
--- a/lib/exprotobuf/decoder.ex
+++ b/lib/exprotobuf/decoder.ex
@@ -9,6 +9,7 @@ defmodule Protobuf.Decoder do
       case type do
         :msg  -> {{:msg, mod}, Enum.map(fields, fn field -> field |> Utils.convert_to_record(Field) end)}
         :enum -> {{:enum, mod}, fields}
+        :extensions -> {{:extensions, mod}, fields}
       end
     end
     :gpb.decode_msg(bytes, module, defs)

--- a/lib/exprotobuf/encoder.ex
+++ b/lib/exprotobuf/encoder.ex
@@ -7,6 +7,7 @@ defmodule Protobuf.Encoder do
       case type do
         :msg  -> {{:msg, mod}, Enum.map(fields, fn field -> field |> Utils.convert_to_record(Field) end)}
         :enum -> {{:enum, mod}, fields}
+        :extensions -> {{:extensions, mod}, fields}
       end
     end
 


### PR DESCRIPTION
gpb already supports extensions, so this was just a matter of adding the `:extensions` token to the encoder and decoder and then writing a test to demonstrate the difference.