### PR TITLE
support encoding messages that included service definitions

### DIFF
--- a/lib/exprotobuf/decoder.ex
+++ b/lib/exprotobuf/decoder.ex
@@ -17,6 +17,7 @@ defmodule Protobuf.Decoder do
           end)}
         :enum       -> {{:enum, mod}, fields}
         :extensions -> {{:extensions, mod}, fields}
+        :service -> {{:service, mod}, fields}
       end
     end
     :gpb.decode_msg(bytes, module, defs)

--- a/lib/exprotobuf/encoder.ex
+++ b/lib/exprotobuf/encoder.ex
@@ -14,6 +14,7 @@ defmodule Protobuf.Encoder do
         end)}
         :enum -> {{:enum, mod}, fields}
         :extensions -> {{:extensions, mod}, fields}
+        :service -> {{:service, mod}, fields}
       end
     end
 

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -9,6 +9,9 @@ defmodule Protobuf.Decoder.Test do
           optional int32 f1 = 1;
           required int32 f2 = 2;
         }
+        service MsgService {
+          rpc hi(Msg) returns (Msg);
+        }
         """
     end
 

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -35,6 +35,10 @@ defmodule Protobuf.Encoder.Test do
 
         required Version version = 1;
       }
+
+      service HelloService {
+        rpc hello (Msg) returns (Msg);
+      }
       """
   end
   


### PR DESCRIPTION
Currently if I load protobuf definitions from a file that includes service definitions, when I try to encode a message I will get an error like:

```
  1) test encoding a message with errors included (MessagesWithErrorsTest)
     test/messages_with_errors_test.exs:4
     ** (CaseClauseError) no case clause matching: :service
     stacktrace:
       lib/exprotobuf/encoder.ex:8: anonymous fn/2 in Protobuf.Encoder.encode/2
       (elixir) lib/enum.ex:1385: Enum."-reduce/3-lists^foldl/2-0-"/3
       lib/exprotobuf/encoder.ex:7: Protobuf.Encoder.encode/2
```

This PR just adds a case clause for services in the encoder so these messages can be encoded. I'm not sure why the encoder cares about `extensions` and `services`, but this seems to work. I'm going to try to fix something a bit more ambitious next so any feedback would be really helpful.