### PR TITLE
Encoding fails in certain cases

### DIFF
--- a/test/proto/chilicat.proto
+++ b/test/proto/chilicat.proto
@@ -1,0 +1,29 @@
+
+enum SGVariantType { VT_STRING = 0; VT_MAP = 1;  }
+
+message SGVariant {
+	required SGVariantType type = 1;
+	oneof value_oneof {
+		string stringValue = 2;
+		SGVariantMap mapValue = 9;
+	}
+}
+
+message SGVariantPair {
+	required string key = 1;
+	required SGVariant value = 2;
+}
+
+message SGVariantMap {
+	repeated SGVariantPair entrySet = 1;
+}
+
+message SGPacket {
+	message SGHeader {
+		required string version = 1;
+		optional SGVariantMap options = 4;
+	}
+
+	required SGHeader header = 1;
+	
+}

--- a/test/protobuf/chilicat_test.exs
+++ b/test/protobuf/chilicat_test.exs
@@ -1,0 +1,21 @@
+defmodule Protobuf.Chilicat.Test do
+  use Protobuf.Case
+
+  defmodule Msgs do
+    use Protobuf, from: Path.expand("../proto/chilicat.proto", __DIR__)
+  end
+
+  test "can encode" do
+    value = Msgs.SGVariant.new(type: :VT_STRING, stringValue: "hello")
+    pair = Msgs.SGVariantPair.new(key: :my_key, value: value)
+    map = Msgs.SGVariantMap.new(entrySet: [ pair  ])
+    
+    header = Msgs.SGPacket.SGHeader.new(version: "myVersion",  options: map)
+
+    # encoding fails if map nested in header.
+    header
+    |> Msgs.SGPacket.SGHeader.encode
+    |> Msgs.SGPacket.SGHeader.decode
+    
+  end
+end


### PR DESCRIPTION

I try to implement one of our existing protobuf templates in elixir. Unfortunately if I try to encode the data structure I just get following error (see below). I have trimmed down my existing protobuf file and created a test case in order to reproduce the issue. 

I'm new to elixir and protobuf so the issue is maybe only my usage, any help is appreciated. 


    1) test can encode (Protobuf.Chilicat.Test)
         test/protobuf/chilicat_test.exs:8
         ** (ArgumentError) argument error
         stacktrace:
           (stdlib) :unicode.characters_to_binary(:my_key)
           (gpb) src/gpb.erl:523: :gpb.encode_value/3
           (gpb) src/gpb.erl:479: :gpb.encode_field_value/4
           (gpb) src/gpb.erl:424: :gpb.encode_2/4
           (gpb) src/gpb.erl:528: :gpb.encode_value/3
           (gpb) src/gpb.erl:479: :gpb.encode_field_value/4
           (gpb) src/gpb.erl:471: :gpb.encode_repeated/5
           (gpb) src/gpb.erl:424: :gpb.encode_2/4
           (gpb) src/gpb.erl:528: :gpb.encode_value/3
           (gpb) src/gpb.erl:479: :gpb.encode_field_value/4
           (gpb) src/gpb.erl:424: :gpb.encode_2/4
           test/protobuf/chilicat_test.exs:17
