### PR TITLE
Bump GPB version to bring in proto3 parsing fix where fields were set…

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "gpb": {:hex, :gpb, "3.24.3", "1a73dc1e023e92c5849c590c9600c98d7c3657038d41c8a29889a580c9be60b3", [:rebar, :make], []}}
+  "gpb": {:hex, :gpb, "3.24.4", "a55e2c7c23212582340596212756f9022d50611feec2040272e20c13b947df44", [:rebar, :make], []}}


### PR DESCRIPTION
… to required by default.