### PR TITLE
Add an option to skip doc generation on generated modules

### DIFF
--- a/lib/exprotobuf.ex
+++ b/lib/exprotobuf.ex
@@ -24,21 +24,24 @@ defmodule Protobuf do
         end
       _ ->
         namespace = Dict.get(opts, :namespace, __CALLER__.module)
+        doc = Dict.get(opts, :doc, nil)
+        opts = Dict.delete(opts, :doc)
         opts = Dict.delete(opts, :namespace)
+
         case opts do
           from: file ->
-            %Config{namespace: namespace, from_file: file}
+            %Config{namespace: namespace, from_file: file, doc: doc}
           from: file, use_package_names: use_package_names ->
-            %Config{namespace: namespace, from_file: file, use_package_names: use_package_names}
+            %Config{namespace: namespace, from_file: file, use_package_names: use_package_names, doc: doc}
           [from: file, only: only] ->
-            %Config{namespace: namespace, only: parse_only(only, __CALLER__), from_file: file}
+            %Config{namespace: namespace, only: parse_only(only, __CALLER__), from_file: file, doc: doc}
           [from: file, inject: true] ->
-            %Config{namespace: namespace,  only: [namespace], inject: true, from_file: file}
+            %Config{namespace: namespace,  only: [namespace], inject: true, from_file: file, doc: doc}
           [from: file, only: only, inject: true] ->
             types = parse_only(only, __CALLER__)
             case types do
               []       -> raise ConfigError, error: "You must specify a type using :only when combined with inject: true"
-              [_type]  -> %Config{namespace: namespace, only: types, inject: true, from_file: file}
+              [_type]  -> %Config{namespace: namespace, only: types, inject: true, from_file: file, doc: doc}
             end
         end
     end

--- a/lib/exprotobuf/builder.ex
+++ b/lib/exprotobuf/builder.ex
@@ -50,6 +50,7 @@ defmodule Protobuf.Builder do
   def generate(msgs, config) do
     only   = Keyword.get(config, :only, [])
     inject = Keyword.get(config, :inject, false)
+    doc    = Keyword.get(config, :doc, true)
     ns     = Keyword.get(config, :namespace)
 
     quotes = for {{item_type, item_name}, fields} <- msgs, item_type in [:msg, :enum], into: [] do
@@ -57,17 +58,17 @@ defmodule Protobuf.Builder do
         is_child? = Enum.any?(only, fn o -> o != item_name and is_child_type?(item_name, o) end)
         if item_name in only or is_child? do
           case item_type do
-            :msg when is_child?  -> def_message(item_name |> fix_ns(ns), fields, inject: false)
-            :msg                 -> def_message(ns, fields, inject: inject)
-            :enum when is_child? -> def_enum(item_name |> fix_ns(ns), fields, inject: false)
-            :enum                -> def_enum(ns, fields, inject: inject)
+            :msg when is_child?  -> def_message(item_name |> fix_ns(ns), fields, inject: false, doc: doc)
+            :msg                 -> def_message(ns, fields, inject: inject, doc: doc)
+            :enum when is_child? -> def_enum(item_name |> fix_ns(ns), fields, inject: false, doc: doc)
+            :enum                -> def_enum(ns, fields, inject: inject, doc: doc)
             _     -> []
           end
         end
       else
         case item_type do
-          :msg  -> def_message(item_name, fields, inject: false)
-          :enum -> def_enum(item_name, fields, inject: false)
+          :msg  -> def_message(item_name, fields, inject: false, doc: doc)
+          :enum -> def_enum(item_name, fields, inject: false, doc: doc)
           _     -> []
         end
       end

--- a/lib/exprotobuf/config.ex
+++ b/lib/exprotobuf/config.ex
@@ -18,5 +18,13 @@ defmodule Protobuf.Config do
             only: [],
             inject: false,
             from_file: nil,
-            use_package_names: false
+            use_package_names: false,
+            doc: nil
+
+
+  def doc_quote(false) do
+    quote do: @moduledoc unquote(false)
+  end
+
+  def doc_quote(_), do: nil
 end

--- a/lib/exprotobuf/define_enum.ex
+++ b/lib/exprotobuf/define_enum.ex
@@ -5,7 +5,7 @@ defmodule Protobuf.DefineEnum do
   Defines a new module which contains two functions, atom(value) and value(atom), for
   getting either the name or value of an enumeration value.
   """
-  def def_enum(name, values, inject: inject) do
+  def def_enum(name, values, [inject: inject, doc: doc]) do
     enum_atoms = Enum.map values, fn {a, _} -> a end
     enum_values = Enum.map values, fn {_, v} -> v end
     contents = for {atom, value} <- values do
@@ -25,6 +25,7 @@ defmodule Protobuf.DefineEnum do
     else
       quote do
         defmodule unquote(name) do
+          unquote(Protobuf.Config.doc_quote(doc))
           unquote(contents)
           def value(_), do: nil
           def atom(_), do: nil
@@ -32,4 +33,5 @@ defmodule Protobuf.DefineEnum do
       end
     end
   end
+
 end

--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -7,7 +7,7 @@ defmodule Protobuf.DefineMessage do
   alias Protobuf.OneOfField
   alias Protobuf.Delimited
 
-  def def_message(name, fields, inject: inject) when is_list(fields) do
+  def def_message(name, fields, [inject: inject, doc: doc]) when is_list(fields) do
     struct_fields = record_fields(fields)
     # Inject everything in 'using' module
     if inject do
@@ -37,6 +37,7 @@ defmodule Protobuf.DefineMessage do
         use_in = @use_in[unquote(name)]
 
         defmodule unquote(name) do
+          unquote(Protobuf.Config.doc_quote(doc))
           @root root
           @record unquote(struct_fields)
           defstruct @record


### PR DESCRIPTION
I'm using exprotobuf in a library of my own, and have found that by default it generates a lot of noise in my documentation (this is expected, of course):

<img width="385" alt="screenshot 2016-08-15 22 37 06" src="https://cloud.githubusercontent.com/assets/778/17687210/d4cacc92-6338-11e6-8728-0dbb900887d1.png">

This PR adds a `doc` option that, when set to `false` will add `@moduledoc false` to each module defined by exprotobuf. It doesn't change the default behavior but allows for those of us for whom those module docs are just noise to opt out.

Example:

```elixir
defmodule MyLib do
  defmodule Proto do
    use Protobuf, from: Path.expand("mydefs.proto", __DIR__), doc: false
  end
end
```