### PR TITLE
Readme update: instruction to add exprotobuf to applications list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ end
 
 Then run `mix deps.get` to fetch.
 
+Add exprotobuf to applications list:
+
+```elixir
+def application do
+  [applications: [:exprotobuf]]
+end
+```
+
 ## Usage
 
 Usage of exprotobuf boils down to a single `use` statement within one or


### PR DESCRIPTION
Exrm seems not to build app correctly, unless exprotobuf is added to applications list.
Adding this installation step to readme