### PR TITLE
Enable default attribute values

### DIFF
--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -121,6 +121,8 @@ defmodule Protobuf.DefineMessage do
       case field do
         %Field{name: name, occurrence: :repeated} ->
           {name, []}
+        %Field{name: name, opts: [default: default]} ->
+          {name, default}
         %Field{name: name} ->
           {name, nil}
         %OneOfField{name: name} ->

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -50,6 +50,22 @@ defmodule ProtobufTest do
     assert [] == msg.f1
   end
 
+  test "set default value if specified explicitly" do
+    defmodule DefaultValueExplicitProto do
+      use Protobuf, "message Msg { optional uint32 f1 = 1 [default = 42]; }"
+    end
+    msg = DefaultValueExplicitProto.Msg.new()
+    assert 42 == msg.f1
+  end
+
+  test "does not set default value if there is a type mismatch" do
+    assert_raise Protobuf.Parser.ParserError, fn ->
+      defmodule DefaultValueExplicitProto do
+        use Protobuf, "message Msg { optional uint32 f1 = 1 [default = -1]; }"
+      end
+    end
+  end
+
   test "define a record in subnamespace" do
     defmodule SubnamespacedRecordProto do
       use Protobuf, """


### PR DESCRIPTION
Protobuf spec allows one to specify a default value
for an optional attriburte.

All the black magic is being performed by gpb
and the default value is returned within a parse result
if specified explicitly. This commit updates DefineMessage
module and makes it respect opts.default attribute.

Refs:
* https://developers.google.com/protocol-buffers/docs/proto#optional
* https://github.com/tomas-abrahamsson/gpb#unset-optionals-and-the-default-option