### PR TITLE
Fix default values for protobuf3

### DIFF
--- a/lib/exprotobuf/decoder.ex
+++ b/lib/exprotobuf/decoder.ex
@@ -43,13 +43,17 @@ defmodule Protobuf.Decoder do
   end
 
   defp get_default(field, module) do
-    case module.defs(:field, field).type do
-      :string ->
-        ""
-      ty ->
-        case :gpb.proto3_type_default(ty, module.defs) do
-          :undefined -> nil
-          default -> default
+    case module.defs(:field, field) do
+      %Protobuf.OneOfField{} -> nil
+      x ->
+        case x.type do
+          :string ->
+            ""
+          ty ->
+            case :gpb.proto3_type_default(ty, module.defs) do
+              :undefined -> nil
+              default -> default
+            end
         end
     end
   end

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -2,7 +2,7 @@ defmodule Protobuf.Decoder.Test do
   use Protobuf.Case
   alias Protobuf.Decoder, as: D
 
-  test "fix :undefined values to nil value" do
+  test "fix :undefined values to default value" do
     defmodule UndefinedValuesProto do
       use Protobuf, """
         message Msg {
@@ -16,7 +16,7 @@ defmodule Protobuf.Decoder.Test do
     end
 
     module = UndefinedValuesProto.Msg
-    assert %{:__struct__ => ^module, :f1 => nil, :f2 => 150} = D.decode(<<16, 150, 1>>, UndefinedValuesProto.Msg)
+    assert %{:__struct__ => ^module, :f1 => 0, :f2 => 150} = D.decode(<<16, 150, 1>>, UndefinedValuesProto.Msg)
   end
 
   test "fix repeated values" do
@@ -56,7 +56,7 @@ defmodule Protobuf.Decoder.Test do
     bytes = <<10, 1, 97, 18, 5, 10, 3, 97, 98, 99>>
     assert %{:__struct__ => ^module, :f1 => "a", :f2 => %{:__struct__ => ^submod, :f1 => "abc"}} = D.decode(bytes, FixingStringValuesProto.Msg)
   end
-  
+
   test "enums" do
     defmodule EnumsProto do
       use Protobuf, """


### PR DESCRIPTION
I've found that exprotobuf handles protobuf3, thanks to gpb. However, default values are not handled correctly: when a field is not sent on the wire, it should be set to its default value ([see here](https://developers.google.com/protocol-buffers/docs/proto3#default)).
For instance, if we have the following definition:
```
syntax="proto3";

enum E {
  A = 0;
  B = 1;
}

message Msg {
  string a = 1;
  int32 b = 2;
  bytes c = 3;
  bool d = 4;
  E e = 5;
}
```

The code `Messages.Msg.decode("")` should output `%Messages.Msg{a: "", b: 0, c: "", d: false, e: :A}`. However, we get the following: `%Messages.Msg{a: nil, b: nil, c: nil, d: nil, e: nil}`.

This commit fixes this. However, there's a slight problem in that it applies unconditionally to protobuf2 and protobuf3 messages. Indeed, I should have used `:gpb.proto2_type_default/2` for the former case, using `:gpb.is_msg_proto3` to detect which function to use. Alas, I can't seem to find how to use it, as I always get `false` as a result, whatever the protobuf version is.