### PR TITLE
Fix bug preventing messages from being encoded

### DIFF
--- a/lib/exprotobuf/utils.ex
+++ b/lib/exprotobuf/utils.ex
@@ -17,6 +17,7 @@ defmodule Protobuf.Utils do
   defp record_name(Field), do: :field
   defp record_name(type), do: type
 
+  defp value_transform(_module, nil), do: :undefined
   defp value_transform(OneOfField, value) when is_list(value) do
     Enum.map(value, &convert_to_record(&1, Field))
   end

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -22,6 +22,56 @@ defmodule ProtobufTest do
     assert ^msg2 = RoundtripProto.Msg2.decode(encoded2)
   end
 
+  test "can encode when protocol is extended with new optional field" do
+    defmodule BasicProto do
+      use Protobuf, """
+      message Msg {
+        required uint32 f1 = 1;
+      }
+      """
+    end
+    old = BasicProto.Msg.new(f1: 1)
+
+    defmodule BasicProto do
+      use Protobuf, """
+      message Msg {
+        required uint32 f1 = 1;
+        optional uint32 f2 = 2;
+      }
+      """
+    end
+    encoded = BasicProto.Msg.encode(old)
+    decoded = BasicProto.Msg.decode(encoded)
+
+    assert 1 = decoded.f1
+    assert 0 = decoded.f2
+  end
+
+  test "can decode when protocol is extended with new optional field" do
+    defmodule BasicProto do
+      use Protobuf, """
+      message Msg {
+        required uint32 f1 = 1;
+      }
+      """
+    end
+    old = BasicProto.Msg.new(f1: 1)
+    encoded = BasicProto.Msg.encode(old)
+
+    defmodule BasicProto do
+      use Protobuf, """
+      message Msg {
+        required uint32 f1 = 1;
+        optional uint32 f2 = 2;
+      }
+      """
+    end
+    decoded = BasicProto.Msg.decode(encoded)
+
+    assert 1 = decoded.f1
+    assert 0 = decoded.f2
+  end
+
   test "define records in namespace" do
     defmodule NamespacedRecordsProto do
       use Protobuf, """


### PR DESCRIPTION
Quoting Protocol Buffers' [official site](https://developers.google.com/protocol-buffers/docs/proto#optional):

>  As mentioned above, elements in a message description can be labeled optional. A well-formed message may or may not contain an optional element. When a message is parsed, if it does not  contain an optional element, the corresponding field in the parsed object is set to the default value for that field. 
> ...
> If the default value is not specified for an optional element, a type-specific default value is used instead: for strings, the default value is the empty string. For bools, the default value is false. For numeric types, the default value is zero. For enums, the default value is the first value listed in the enum's type definition.

also

> Any new fields that you add should be optional or repeated. This means that any messages serialized by code using your "old" message format can be parsed by your new generated code, as they won't be missing any required elements. You should set up sensible default values for these elements so that new code can properly interact with messages generated by old code.

However, I've recently noticed that ExProtobuf does not handle this situation particularly well. That is, ExProtobuf chokes when one attempts to encode a message, in its Elixir form, using an updated message specification. 

Imagine that one has the following message specification:
```
message Msg {
    required uint32 f1 = 1;
}
```

Assume that we have an Elixir system that is handling messages encoded according to the above specification. At some point, the system decodes the message (i.e. converts it to an Elixir data structure) and saves it to disk.

Imagine now that we roll out an updated version of the message specification:
```
message Msg {
    required uint32 f1 = 1;
    optional uint32 f2 = 2;
}
```

In an attempt to keep the protocol backwards compatible, we have added the new field as optional. However, we will soon realise that this design made very little difference since ExProtobuf is unable to use the new specification to encode the messages that we had previously decoded using the old message specification.

```elixir
** (ArithmeticError) bad argument in arithmetic expression
    (gpb) src/gpb.erl:728: :gpb.en_vi/1
    (gpb) src/gpb.erl:603: :gpb.encode_field_value/4
    (gpb) src/gpb.erl:538: :gpb.encode_2/4
```

This pull-request provides a fix for this behaviour.