### PR TITLE
Fix proto2 defaults

### DIFF
--- a/lib/exprotobuf/builder.ex
+++ b/lib/exprotobuf/builder.ex
@@ -53,34 +53,42 @@ defmodule Protobuf.Builder do
     doc    = Keyword.get(config, :doc, true)
     ns     = Keyword.get(config, :namespace)
 
-    quotes = for {{item_type, item_name}, fields} <- msgs, item_type in [:msg, :enum], into: [] do
+    quotes = for {{item_type, item_name}, fields} <- msgs, item_type in [:msg, :proto3_msg, :enum], into: [] do
       if only != [] do
         is_child? = Enum.any?(only, fn o -> o != item_name and is_child_type?(item_name, o) end)
         if item_name in only or is_child? do
           case item_type do
-            :msg when is_child?  -> def_message(item_name |> fix_ns(ns), fields, inject: false, doc: doc)
-            :msg                 -> def_message(ns, fields, inject: inject, doc: doc)
-            :enum when is_child? -> def_enum(item_name |> fix_ns(ns), fields, inject: false, doc: doc)
-            :enum                -> def_enum(ns, fields, inject: inject, doc: doc)
+            :msg when is_child?         -> def_message(item_name |> fix_ns(ns), fields, inject: false, doc: doc, syntax: :proto2)
+            :msg                        -> def_message(ns, fields, inject: inject, doc: doc, syntax: :proto2)
+            :proto3_msg when is_child?  -> def_message(item_name |> fix_ns(ns), fields, inject: false, doc: doc, syntax: :proto3)
+            :proto3_msg                 -> def_message(ns, fields, inject: inject, doc: doc, syntax: :proto3)
+            :enum when is_child?        -> def_enum(item_name |> fix_ns(ns), fields, inject: false, doc: doc)
+            :enum                       -> def_enum(ns, fields, inject: inject, doc: doc)
             _     -> []
           end
         end
       else
         case item_type do
-          :msg  -> def_message(item_name, fields, inject: false, doc: doc)
-          :enum -> def_enum(item_name, fields, inject: false, doc: doc)
+          :msg         -> def_message(item_name, fields, inject: false, doc: doc, syntax: :proto2)
+          :proto3_msg  -> def_message(item_name, fields, inject: false, doc: doc, syntax: :proto3)
+          :enum        -> def_enum(item_name, fields, inject: false, doc: doc)
           _     -> []
         end
       end
     end
 
+    unified_msgs = msgs |> Enum.map(&unify_msg_types/1)
+
     # Global defs helper
     quotes ++ [quote do
       def defs do
-        unquote(Macro.escape(msgs, unquote: true))
+        unquote(Macro.escape(unified_msgs, unquote: true))
       end
     end]
   end
+
+  defp unify_msg_types({{:proto3_msg, name}, fields}), do: {{:msg, name}, fields}
+  defp unify_msg_types(other),                         do: other
 
   defp is_child_type?(child, type) do
     [parent|_] = child |> Atom.to_string |> String.split(".", parts: :infinity)

--- a/lib/exprotobuf/decoder.ex
+++ b/lib/exprotobuf/decoder.ex
@@ -35,14 +35,17 @@ defmodule Protobuf.Decoder do
       field, %{__struct__: module} = msg ->
         value = Map.get(msg, field)
         if value == :undefined do
-          Map.put(msg, field, get_default(field, module))
+          Map.put(msg, field, get_default(module.syntax(), field, module))
         else
           convert_field(value, msg, module.defs(:field, field))
         end
     end)
   end
 
-  defp get_default(field, module) do
+  defp get_default(:proto2, field, module) do
+    Map.get(struct(module), field)
+  end
+  defp get_default(:proto3, field, module) do
     case module.defs(:field, field) do
       %Protobuf.OneOfField{} -> nil
       x ->

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -2,21 +2,36 @@ defmodule Protobuf.Decoder.Test do
   use Protobuf.Case
   alias Protobuf.Decoder, as: D
 
-  test "fix :undefined values to default value" do
-    defmodule UndefinedValuesProto do
+  test "fix :undefined values to nil in proto2" do
+    defmodule UndefinedValuesProto2 do
       use Protobuf, """
         message Msg {
-          optional int32 f1 = 1;
-          required int32 f2 = 2;
-        }
-        service MsgService {
-          rpc hi(Msg) returns (Msg);
+          optional string f1 = 1;
+          optional int32 f2 = 2;
+          optional bool f3 = 3;
         }
         """
     end
 
-    module = UndefinedValuesProto.Msg
-    assert %{:__struct__ => ^module, :f1 => 0, :f2 => 150} = D.decode(<<16, 150, 1>>, UndefinedValuesProto.Msg)
+    module = UndefinedValuesProto2.Msg
+    assert %{__struct__: ^module, f1: nil, f2: nil, f3: nil} = D.decode("", module)
+  end
+
+  test "fix :undefined values to default value in proto3" do
+    defmodule UndefinedValuesProto3 do
+      use Protobuf, """
+        syntax = "proto3";
+
+        message Msg {
+          string f1 = 1;
+          int32 f2 = 2;
+          bool f3 = 3;
+        }
+        """
+    end
+
+    module = UndefinedValuesProto3.Msg
+    assert %{__struct__: ^module, f1: "", f2: 0, f3: false} = D.decode("", module)
   end
 
   test "fix repeated values" do


### PR DESCRIPTION
Example 1
There's breaking change in defaults for proto2 (1.2.2 .. master)
Probably related to #63

```elixir
defmodule Proto2 do
  use Protobuf, """
    message M {
      optional string text = 1;
    }
  """
end  

#1.2.1
iex() > Proto2.M.decode("") 
%Proto2.M2{text: nil}
#1.22
iex() > Proto2.M.decode("") 
%Proto2.M2{text: ""} 
#master
iex() > Proto2.M.decode("") 
%Proto2.M2{text: ""}
#this PR
iex() > Proto2.M.decode("") 
%Proto2.M2{text: nil}
```

I don't think that implicit default values for basic types are worth losing the ability to see whether a field is present or not.
It could be configurable same way as in gpb (see `Unset optionals and the default option` in gpb readme), but I would prefer to fix breaking changes first and leave this improvement for separate PR

Example 2
Constructor functions in current version generate default values for `required` field. It shouldn't. In fact I would expect `encode` function to raise when there's no explicit value set for `required` field.

This is because function which generates default values is based on occurancy instead of syntax.

```elixir
defmodule Proto2 do
  use Protobuf, """
    message M {
      required string x = 1;
      optional string y = 2;
    }
  """
end

iex> Proto2.M.new
%Proto2.M{x: nil, y: nil} #1.2.4
%Proto2.M{x: "",  y: nil} #master
%Proto2.M{x: nil, y: nil} #this PR
```