### PR TITLE
fixed string decoding (inside oneof)

### DIFF
--- a/lib/exprotobuf/decoder.ex
+++ b/lib/exprotobuf/decoder.ex
@@ -82,6 +82,8 @@ defmodule Protobuf.Decoder do
         module = elem(inner_value, 0)
         converted_value = {key, inner_value |> Utils.convert_from_record(module) |> convert_fields}
         Map.put(msg, field, converted_value)
+      is_list(inner_value) ->
+        Map.put(msg, field, {key, convert_value(:string, inner_value)})
       true ->
         Map.put(msg, field, value)
     end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "gpb": {:hex, :gpb, "3.27.0", "bc0e6d2a3eb11dc7c0f37a061e8dc110b8a4c0af49d3e564dff89890c1d11e04", [:make, :rebar], [], "hexpm"}}
+%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "gpb": {:hex, :gpb, "3.27.0", "bc0e6d2a3eb11dc7c0f37a061e8dc110b8a4c0af49d3e564dff89890c1d11e04", [:make, :rebar], []}}

--- a/test/protobuf/one_of_test.exs
+++ b/test/protobuf/one_of_test.exs
@@ -23,7 +23,7 @@ defmodule Protobuf.Oneof.Test do
     binary = <<10, 4, 116, 101, 115, 116, 26, 3, 120, 120, 120>>
 
     msg = Msgs.SampleOneofMsg.decode(binary)
-    assert %Msgs.SampleOneofMsg{foo: {:body, 'xxx'}, one: "test"} == msg
+    assert %Msgs.SampleOneofMsg{foo: {:body, "xxx"}, one: "test"} == msg
   end
 
   test "stucture parsed simple one_of proto properly" do

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -8,14 +8,20 @@ defmodule ProtobufTest do
         optional string f1 = 1;
         optional string f2 = 2 [default = "test"];
         optional uint32 f3 = 3;
+        oneof f4 {
+          string f4a = 4;
+        }
       }
       """
     end
 
-    msg = RoundtripProto2.Msg.new()
-    encoded = RoundtripProto2.Msg.encode(msg)
+    msg1 = RoundtripProto2.Msg.new()
+    encoded1 = RoundtripProto2.Msg.encode(msg1)
+    assert %{f1: nil, f2: "test", f3: nil, f4: nil} = RoundtripProto2.Msg.decode(encoded1)
 
-    assert %{f1: nil, f2: "test", f3: nil} = RoundtripProto2.Msg.decode(encoded)
+    msg2 = RoundtripProto2.Msg.new(f4: {:f4a, "test"})
+    encoded2 = RoundtripProto2.Msg.encode(msg2)
+    assert %{f4: {:f4a, "test"}} = RoundtripProto2.Msg.decode(encoded2)
   end
 
   test "can roundtrip encoding/decoding optional values in proto3" do
@@ -27,14 +33,20 @@ defmodule ProtobufTest do
         string f1 = 1;
         uint32 f2 = 2;
         bool f3 = 3;
+        oneof f4 {
+          string f4a = 4;
+        }
       }
       """
     end
 
-    msg = RoundtripProto3.Msg.new()
-    encoded = RoundtripProto3.Msg.encode(msg)
+    msg1 = RoundtripProto3.Msg.new()
+    encoded1 = RoundtripProto3.Msg.encode(msg1)
+    assert %{f1: "", f2: 0, f3: false, f4: nil} = RoundtripProto3.Msg.decode(encoded1)
 
-    assert %{f1: "", f2: 0, f3: false} = RoundtripProto3.Msg.decode(encoded)
+    msg2 = RoundtripProto3.Msg.new(f4: {:f4a, "test"})
+    encoded2 = RoundtripProto3.Msg.encode(msg2)
+    assert %{f4: {:f4a, "test"}} = RoundtripProto3.Msg.decode(encoded2)
   end
 
   test "can encode when protocol is extended with new optional field" do


### PR DESCRIPTION
As far as I remember `repeated` can't be used inside `oneof`, so only list we can get inside oneof is character list (string field).

#71