### PR TITLE
add failing test for submsg type mismatch

### DIFF
--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -40,7 +40,7 @@ defmodule Protobuf.Encoder.Test do
       }
       """
   end
-  
+
   #defmodule ExtensionsProto do
     #use Protobuf, """
     #message Msg {
@@ -74,6 +74,13 @@ defmodule Protobuf.Encoder.Test do
     assert <<8, 1>> == Protobuf.Serializable.serialize(msg)
   end
 
+  test "fails an invalid value for a submsg" do
+    wrong_msg = EncoderProto.WithRepeatedSubMsg.new(f1: [EncoderProto.Msg.new(f1: 1)])
+    msg = EncoderProto.WithSubMsg.new(f1: wrong_msg)
+    assert_raise(ErlangError, "some error from gpb I'm guessing", fn ->
+      Protobuf.Serializable.serialize(msg)
+    end)
+  end
   #test "it can create an extended message" do
     #msg = ExtensionsProto.Msg.new(name: "Ron", pseudonym: "Duke Silver")
     #assert msg == %ExtensionsProto.Msg{name: "Ron", pseudonym: "Duke Silver"}


### PR DESCRIPTION
I opened this PR after we noticed that some messages containing `Any` and `OneOf` messages weren't being type checked if given incorrect values. After some poking, it seemed to be any nested messages.

It also has the nasty issue that when it's decoded it looks like it populates optionals with their defaults recursively. I didn't show that in this PR as we saw it in proto3, but if you are unsure what I mean I can put together and comment with a sanitized example.

Ultimately, we were somewhat able to protect against this by calling an encode & decode on the message, and throwing an error if they aren't equal, but this was less than ideal, and requires communicating that caveat to any folks sending us messages as well.

Let me know what you think. We're slowly digging into the source for `gpb` since this seems like an issue with that, but I figured I'd start here.

If you'd prefer this as an issue I can move it. I was just looking through the code anyway and figured I'd write a test.