### PR TITLE
new/1 accepts map as an argument

### DIFF
--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -68,9 +68,11 @@ defmodule Protobuf.DefineMessage do
 
   defp constructors(name) do
     quote location: :keep do
-      def new(), do: new([])
+      def new(), do: new(%{})
       def new(values) when is_list(values) do
-        values = Enum.into(values, %{})
+        values |> Enum.into(%{}) |> new()
+      end
+      def new(values) when is_map(values) do
         s = struct(unquote(name))
         keys = Map.keys(Map.from_struct(s))
         Enum.reduce(keys, s, fn


### PR DESCRIPTION
### Motivation
Sometimes (in my case - almost every time) I need to build proto-structure from a map (my serializers return maps) and there odd work occured: `map -> keywords -> map` that takes reasonable time on big maps.

### Implementation
I've just skipped an odd convertation `keywords -> map` in `new/1` and made a map default argument.