### PR TITLE
fix decoding proto with oneof fields on 1 and 3 position with 3 options

### DIFF
--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -96,8 +96,8 @@ defmodule Protobuf.DefineMessage do
   defp oneof_fields_methods(fields) do
     for %OneOfField{name: name, rnum: rnum} = field <- fields do
       quote location: :keep do
-        def defs(:field, unquote(rnum)), do: unquote(Macro.escape(field))
-        def defs(:field, unquote(name)), do: defs(:field, unquote(rnum))
+        def defs(:field, unquote(rnum - 1)), do: unquote(Macro.escape(field))
+        def defs(:field, unquote(name)), do: defs(:field, unquote(rnum - 1))
       end
     end
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "gpb": {:hex, :gpb, "3.27.6", "fa7f40fb6966ec79d3efe7fc713167552f943c777e45110e064f97f5aaa20c83", [:make, :rebar], [], "hexpm"}}
+%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "gpb": {:hex, :gpb, "3.27.6", "fa7f40fb6966ec79d3efe7fc713167552f943c777e45110e064f97f5aaa20c83", [:make, :rebar], []}}

--- a/test/proto/one_of.proto
+++ b/test/proto/one_of.proto
@@ -6,8 +6,8 @@ message SampleOneofMsg {
   optional string one = 1;
 
   oneof foo {
-    string body = 3;
-    uint32 code = 4;
+      string body = 2;
+      uint32 code = 3;
   }
 }
 
@@ -15,16 +15,31 @@ message AdvancedOneofMsg {
   optional SubMsg one = 1;
 
   oneof foo {
-    SubMsg body = 3;
-    uint32 code = 4;
+    SubMsg body = 2;
+    uint32 code = 3;
   }
 }
 
 message ReversedOrderOneOfMsg {
-	oneof foo {
-		string body = 1;
-		uint32 code = 2;
-	}
+  oneof foo {
+    string body = 1;
+    uint32 code = 2;
+  }
 
-	optional string bar = 3;
+  optional string bar = 3;
+}
+
+message SurroundOneOfMsg {
+  oneof foo {
+    string body = 1;
+    uint32 code = 2;
+    uint32 third = 3;
+  }
+
+  optional string bar = 4;
+
+  oneof buzz {
+     string one = 5;
+     uint32 two = 6;
+  }
 }

--- a/test/protobuf/one_of_test.exs
+++ b/test/protobuf/one_of_test.exs
@@ -14,23 +14,23 @@ defmodule Protobuf.Oneof.Test do
     msg = Msgs.SampleOneofMsg.new(one: "test", foo: {:body, "xxx"})
 
     encoded = Protobuf.Serializable.serialize(msg)
-    binary = <<10, 4, 116, 101, 115, 116, 26, 3, 120, 120, 120>>
+    binary = <<10, 4, 116, 101, 115, 116, 18, 3, 120, 120, 120>>
 
     assert binary == encoded
   end
 
   test "can decode simple one_of protos" do
-    binary = <<10, 4, 116, 101, 115, 116, 26, 3, 120, 120, 120>>
+    binary = <<10, 4, 116, 101, 115, 116, 18, 3, 120, 120, 120>>
 
     msg = Msgs.SampleOneofMsg.decode(binary)
     assert %Msgs.SampleOneofMsg{foo: {:body, "xxx"}, one: "test"} == msg
   end
 
-  test "stucture parsed simple one_of proto properly" do
+  test "structure parsed simple one_of proto properly" do
     defs = Msgs.SampleOneofMsg.defs(:field, :foo)
 
-    assert %Protobuf.OneOfField{fields: [%Protobuf.Field{fnum: 3, name: :body, occurrence: :optional, opts: [], rnum: 3, type: :string},
-              %Protobuf.Field{fnum: 4, name: :code, occurrence: :optional, opts: [], rnum: 3, type: :uint32}], name: :foo, rnum: 3} = defs
+    assert %Protobuf.OneOfField{fields: [%Protobuf.Field{fnum: 2, name: :body, occurrence: :optional, opts: [], rnum: 3, type: :string},
+              %Protobuf.Field{fnum: 3, name: :code, occurrence: :optional, opts: [], rnum: 3, type: :uint32}], name: :foo, rnum: 3} = defs
 
   end
 
@@ -47,13 +47,13 @@ defmodule Protobuf.Oneof.Test do
 
     encoded = Protobuf.Serializable.serialize(msg)
 
-    binary = <<10, 5, 10, 3, 120, 120, 120, 26, 5, 10, 3, 121, 121, 121>>
+    binary = <<10, 5, 10, 3, 120, 120, 120, 18, 5, 10, 3, 121, 121, 121>>
 
     assert binary == encoded
   end
 
   test "can decode one_of protos with sub messages" do
-    binary = <<10, 5, 10, 3, 120, 120, 120, 26, 5, 10, 3, 121, 121, 121>>
+    binary = <<10, 5, 10, 3, 120, 120, 120, 18, 5, 10, 3, 121, 121, 121>>
 
     msg = Msgs.AdvancedOneofMsg.decode(binary)
     assert %Msgs.AdvancedOneofMsg{foo: {:body,  Msgs.SubMsg.new(test: "yyy")}, one: Msgs.SubMsg.new(test: "xxx")} == msg
@@ -73,5 +73,36 @@ defmodule Protobuf.Oneof.Test do
     assert Msgs.ReversedOrderOneOfMsg.new(foo: {:code, 32}, bar: "hi") == dec_msg
   end
 
+  test "can encode one_of protos with one_of field on first and third position with three options" do
+    msg = Msgs.SurroundOneOfMsg.new(foo: {:code, 32}, bar: "hi", buzz: {:one, "3"})
+    enc_msg = Protobuf.Serializable.serialize(msg)
 
+    assert is_binary(enc_msg)
+  end
+
+  test "can decode one_of protos with one_of field on first and third position with three options" do
+    enc_msg= <<16, 32, 34, 2, 104, 105, 42, 1, 51>>
+    dec_msg = Msgs.SurroundOneOfMsg.decode(enc_msg)
+
+    assert Msgs.SurroundOneOfMsg.new(foo: {:code, 32}, bar: "hi", buzz: {:one, "3"}) == dec_msg
+  end
+
+  test "structure parsed with surrounding one_of proto field with three options properly" do
+    foo_defs = Msgs.SurroundOneOfMsg.defs(:field, :foo)
+
+    assert  %Protobuf.OneOfField{fields: [%Protobuf.Field{fnum: 1, name: :body, occurrence: :optional, opts: [], rnum: 2, type: :string},
+               %Protobuf.Field{fnum: 2, name: :code, occurrence: :optional, opts: [], rnum: 2, type: :uint32},
+               %Protobuf.Field{fnum: 3, name: :third, occurrence: :optional, opts: [], rnum: 2, type: :uint32}], name: :foo, rnum: 2}
+            = foo_defs
+
+    bar_defs = Msgs.SurroundOneOfMsg.defs(:field, :bar)
+
+    assert %Protobuf.Field{fnum: 4, name: :bar, occurrence: :optional, opts: [], rnum: 3, type: :string} = bar_defs
+
+    buzz_defs = Msgs.SurroundOneOfMsg.defs(:field, :buzz)
+
+    assert %Protobuf.OneOfField{fields: [%Protobuf.Field{fnum: 5, name: :one, occurrence: :optional, opts: [], rnum: 4, type: :string},
+              %Protobuf.Field{fnum: 6, name: :two, occurrence: :optional, opts: [], rnum: 4, type: :uint32}], name: :buzz, rnum: 4}
+           = buzz_defs
+  end
 end


### PR DESCRIPTION
**BUG**
 Found bug, when proto message has two oneof fields separated by another field, and first oneof has 3 fields inside.
  ```
  message SurroundOneOfMsg {
    oneof foo {
      string body = 1;
      uint32 code = 2;
      uint32 third = 3;
    }

    optional string bar = 4;

    oneof buzz {
       string one = 5;
       uint32 two = 6;
   }
}
  ```

  ```
  iex>  Msgs.SurroundOneOfMsg.new(foo: {:code, 32}, bar: "hi", buzz: {:one, "3"}) |> Msgs.SurroundOneOfMsg.encode() |> Msgs.SurroundOneOfMsg.decode()
  ** (ArgumentError) argument error
      (stdlib) :unicode.characters_to_binary({:one, '3'})
      (exprotobuf) lib/exprotobuf/decoder.ex:69: Protobuf.Decoder.convert_field/3
      (elixir) lib/enum.ex:1811: Enum."-reduce/3-lists^foldl/2-0-"/3

  iex>  Msgs.SurroundOneOfMsg.defs(:field, :buzz)
  %Protobuf.Field{fnum: 4, name: :bar, occurrence: :optional, opts: [], rnum: 3,
   type: :string}
  ```
`defs` returns wrong field, I guess because of `rnum` and `fnum` difference.

**SOLUTION**
I changed `defs` definition for oneof fields to
```
def defs(:field, unquote(rnum - 1)), do: unquote(Macro.escape(field))
def defs(:field, unquote(name)), do: defs(:field, unquote(rnum - 1))
```
And now it works well
```
iex>  Msgs.SurroundOneOfMsg.new(foo: {:code, 32}, bar: "hi", buzz: {:one, "3"}) |> Msgs.SurroundOneOfMsg.encode() |> Msgs.SurroundOneOfMsg.decode()
%Msgs.SurroundOneOfMsg{bar: "hi", buzz: {:one, "3"}, foo: {:code, 32}}

iex> Msgs.SurroundOneOfMsg.defs(:field, :buzz)
%Protobuf.OneOfField{fields: [%Protobuf.Field{fnum: 5, name: :one,
   occurrence: :optional, opts: [], rnum: 4, type: :string},
  %Protobuf.Field{fnum: 6, name: :two, occurrence: :optional, opts: [], rnum: 4,
   type: :uint32}], name: :buzz, rnum: 4}
```
