### PR TITLE
Encoding/Decoding optional string turns nil into empty string (in/for proto3).

### DIFF
--- a/test/proto/simple2.proto
+++ b/test/proto/simple2.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+message Basic {
+  required uint32 f1 = 1;
+  optional string f2 = 2;
+}

--- a/test/proto/simple3.proto
+++ b/test/proto/simple3.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message Basic {
+  required uint32 f1 = 1;
+  optional string f2 = 2;
+}

--- a/test/proto/simple3b.proto
+++ b/test/proto/simple3b.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message Basic {
+  uint32 f1 = 1;
+  string f2 = 2;
+}

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -129,6 +129,36 @@ defmodule ProtobufTest do
     assert 1 == decoded.f1
   end
 
+  test "can encode when inject is used and definition loaded from a file - proto2" do
+    defmodule Basic do
+      use Protobuf, from: Path.expand("./proto/simple2.proto", __DIR__), inject: true
+    end
+    basic = Basic.new(f1: 1)
+    encoded = Basic.encode(basic)
+    decoded = Basic.decode(encoded)
+    assert basic == decoded
+  end
+
+  test "can encode when inject is used and definition loaded from a file - proto3" do
+    defmodule Basic do
+      use Protobuf, from: Path.expand("./proto/simple3.proto", __DIR__), inject: true
+    end
+    basic = Basic.new(f1: 1)
+    encoded = Basic.encode(basic)
+    decoded = Basic.decode(encoded)
+    assert basic == decoded
+  end
+
+  test "can encode when inject is used and definition loaded from a file - proto3b" do
+    defmodule Basic do
+      use Protobuf, from: Path.expand("./proto/simple3b.proto", __DIR__), inject: true
+    end
+    basic = Basic.new(f1: 1)
+    encoded = Basic.encode(basic)
+    decoded = Basic.decode(encoded)
+    assert basic == decoded
+  end
+
   test "can decode when protocol is extended with new optional field" do
     defmodule BasicProto do
       use Protobuf, """


### PR DESCRIPTION
Hi All, 

just stumbled over this testcase.

The proto2 behavior makes sense to me.

The proto3 behavior not so much.

Is this a bug?

Regards ...
    Roland

