### PR TITLE
Adapt for gpb ~> 4.7.1

### DIFF
--- a/lib/exprotobuf/parser.ex
+++ b/lib/exprotobuf/parser.ex
@@ -49,7 +49,7 @@ defmodule Protobuf.Parser do
   end
 
   defp parse(path, string, options) when is_binary(string) or is_list(string) do
-    case :gpb_scan.string('#{string}') do
+    case :gpb_scan.string(to_charlist(string)) do
       {:ok, tokens, _} ->
         lines =
           string
@@ -58,7 +58,7 @@ defmodule Protobuf.Parser do
 
         case :gpb_parse.parse(tokens ++ [{:"$end", lines + 1}]) do
           {:ok, defs} ->
-            :gpb_parse.post_process_one_file(Atom.to_charlist(path), defs, options)
+            :gpb_parse.post_process_one_file(to_charlist(path), defs, options)
 
           error ->
             error

--- a/lib/exprotobuf/parser.ex
+++ b/lib/exprotobuf/parser.ex
@@ -58,7 +58,7 @@ defmodule Protobuf.Parser do
 
         case :gpb_parse.parse(tokens ++ [{:"$end", lines + 1}]) do
           {:ok, defs} ->
-            :gpb_parse.post_process_one_file('#{path}', defs, options)
+            :gpb_parse.post_process_one_file(String.to_charlist(path), defs, options)
 
           error ->
             error

--- a/lib/exprotobuf/parser.ex
+++ b/lib/exprotobuf/parser.ex
@@ -58,7 +58,7 @@ defmodule Protobuf.Parser do
 
         case :gpb_parse.parse(tokens ++ [{:"$end", lines + 1}]) do
           {:ok, defs} ->
-            :gpb_parse.post_process_one_file(String.to_charlist(path), defs, options)
+            :gpb_parse.post_process_one_file(Atom.to_charlist(path), defs, options)
 
           error ->
             error

--- a/lib/exprotobuf/parser.ex
+++ b/lib/exprotobuf/parser.ex
@@ -58,7 +58,7 @@ defmodule Protobuf.Parser do
 
         case :gpb_parse.parse(tokens ++ [{:"$end", lines + 1}]) do
           {:ok, defs} ->
-            :gpb_parse.post_process_one_file(path, defs, options)
+            :gpb_parse.post_process_one_file('#{path}', defs, options)
 
           error ->
             error


### PR DESCRIPTION
Hello,

After upgrade `exprotobuf` to 1.2.16, and meanwhile use `gpb ~> 4.7.1` there will occur an ```:erlang.++("basic", ".proto")``` argument error in `gpb`, here's a [discussion](https://github.com/tomas-abrahamsson/gpb/pull/167) in `gpb` .

This PR works fine with `gpb ~> 4.0`, @bitwalker @tim2CF please review.