### PR TITLE
Allow the use of from_file, inject and use_package_names at the same time

### DIFF
--- a/lib/exprotobuf.ex
+++ b/lib/exprotobuf.ex
@@ -55,6 +55,48 @@ defmodule Protobuf do
 
     config =
       case opts do
+        %{from: file, use_package_names: use_package_names, only: only, inject: true} ->
+          types = parse_only(only, __CALLER__)
+
+          case types do
+            [] ->
+              raise ConfigError,
+                error: "You must specify a type using :only when combined with inject: true"
+
+            [_type] ->
+              %Config{
+                namespace: namespace,
+                only: types,
+                inject: true,
+                use_package_names: use_package_names,
+                from_file: file,
+                doc: doc
+              }
+          end
+
+          only = last_module(namespace)
+
+          %Config{
+            namespace: namespace,
+            only: [only],
+            from_file: file,
+            inject: true,
+            use_package_names: use_package_names,
+            doc: doc
+          }
+
+        %{from: file, use_package_names: use_package_names, inject: true} ->
+          only = last_module(namespace)
+
+          %Config{
+            namespace: namespace,
+            only: [only],
+            from_file: file,
+            inject: true,
+            use_package_names: use_package_names,
+            doc: doc
+          }
+
         %{from: file, use_package_names: use_package_names} ->
           %Config{
             namespace: namespace,

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -207,6 +207,17 @@ defmodule ProtobufTest do
     assert ns_field_b == B
   end
 
+  test "allow inject, use_package_names and from_file at the same time" do
+    defmodule Version do
+      use Protobuf,
+        from: Path.expand("./proto/mumble.proto", __DIR__),
+        inject: true,
+        use_package_names: true
+    end
+
+    assert Keyword.has_key?(Version.__info__(:functions), :new)
+  end
+
   test "do not set default value for optional" do
     defmodule DefaultValueForOptionalsProto do
       use Protobuf, "message Msg { optional uint32 f1 = 1; }"


### PR DESCRIPTION
Allow the use of from_file, inject and use_package_names at the same time:

This allows, for example, to load a Google descriptor file and parse a protobuf
file containing user-defined annotated options (by extending
google.protobuf.FieldOptions).