### PR TITLE
Use rnum for both ordinary and oneof field defs.

### DIFF
--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -340,10 +340,10 @@ defmodule Protobuf.DefineMessage do
   end
 
   defp fields_methods(fields) do
-    for %Field{name: name, fnum: fnum} = field <- fields do
+    for %Field{name: name, rnum: rnum} = field <- fields do
       quote location: :keep do
-        def defs(:field, unquote(fnum)), do: unquote(Macro.escape(field))
-        def defs(:field, unquote(name)), do: defs(:field, unquote(fnum))
+        def defs(:field, unquote(rnum)), do: unquote(Macro.escape(field))
+        def defs(:field, unquote(name)), do: defs(:field, unquote(rnum))
       end
     end
   end
@@ -351,8 +351,8 @@ defmodule Protobuf.DefineMessage do
   defp oneof_fields_methods(fields) do
     for %OneOfField{name: name, rnum: rnum} = field <- fields do
       quote location: :keep do
-        def defs(:field, unquote(rnum - 1)), do: unquote(Macro.escape(field))
-        def defs(:field, unquote(name)), do: defs(:field, unquote(rnum - 1))
+        def defs(:field, unquote(rnum)), do: unquote(Macro.escape(field))
+        def defs(:field, unquote(name)), do: defs(:field, unquote(rnum))
       end
     end
   end

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -332,7 +332,7 @@ defmodule ProtobufTest do
       use Protobuf, "message Msg { optional uint32 f1 = 1; }"
     end
     deff = %Protobuf.Field{name: :f1, fnum: 1, rnum: 2, type: :uint32, occurrence: :optional, opts: []}
-    assert deff == FieldDefsProto.Msg.defs(:field, 1)
+    assert deff == FieldDefsProto.Msg.defs(:field, 2)
     assert deff == FieldDefsProto.Msg.defs(:field, :f1)
   end
 


### PR DESCRIPTION
I've had a problem when decoding a nested structure with oneof fields. When calling the function defs/2 with :field and the fileld name of the oneof field, the def of another field is returned, so the oneof is not properly handled. It seems that the rnum-1 does not behave as expected for all cases. I can't find any other uses of defs than in the Decoder, so I therefore just changed the behaviour.