### PR TITLE
filter reserved_numbers and reserved_names tuples when converting from gpb representation

### DIFF
--- a/lib/exprotobuf.ex
+++ b/lib/exprotobuf.ex
@@ -197,7 +197,8 @@ defmodule Protobuf do
 
   # Apply namespace to top-level types
   defp namespace_types(parsed, ns, inject) do
-    for {{type, name}, fields} <- parsed, is_atom(name) and type != :reserved_numbers do
+    for {{type, name}, fields} <- parsed,
+    is_atom(name) and type != :reserved_numbers and type != :reserved_names do
       parsed_type = if :gpb.is_msg_proto3(name, parsed), do: :proto3_msg, else: type
 
       if inject do

--- a/lib/exprotobuf.ex
+++ b/lib/exprotobuf.ex
@@ -197,8 +197,7 @@ defmodule Protobuf do
 
   # Apply namespace to top-level types
   defp namespace_types(parsed, ns, inject) do
-    for {{type, name}, fields} <- parsed,
-    is_atom(name) and type != :reserved_numbers and type != :reserved_names do
+    for {{type, name}, fields} <- parsed, is_atom(name) do
       parsed_type = if :gpb.is_msg_proto3(name, parsed), do: :proto3_msg, else: type
 
       if inject do

--- a/lib/exprotobuf.ex
+++ b/lib/exprotobuf.ex
@@ -197,7 +197,7 @@ defmodule Protobuf do
 
   # Apply namespace to top-level types
   defp namespace_types(parsed, ns, inject) do
-    for {{type, name}, fields} <- parsed, is_atom(name) do
+    for {{type, name}, fields} <- parsed, is_atom(name) and type != :reserved_numbers do
       parsed_type = if :gpb.is_msg_proto3(name, parsed), do: :proto3_msg, else: type
 
       if inject do

--- a/lib/exprotobuf/parser.ex
+++ b/lib/exprotobuf/parser.ex
@@ -18,10 +18,16 @@ defmodule Protobuf.Parser do
     |> finalize!(options)
   end
 
+  ## filter information about reserved numbers/names,
+  ## as they are useless in this context
+  defp filter_reserved({{:reserved_names, _}, _}), do: false
+  defp filter_reserved({{:reserved_numbers, _}, _}), do: false
+  defp filter_reserved(_), do: true
+
   defp finalize!(defs, options) do
     case :gpb_parse.post_process_all_files(defs, options) do
       {:ok, defs} ->
-        defs
+        defs |> Enum.filter(&filter_reserved/1)
 
       {:error, error} ->
         msg =

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -12,10 +12,21 @@ defmodule ProtobufTest do
             string f1 = 1;
         }
         """
-    end 
+    end
+
+    defmodule ReservedProto2 do
+        use Protobuf, """
+        message Foo {
+            reserved 2, 15, 9 to 11;
+            reserved "foo", "bar";
+            string f1 = 1;
+        }
+        """
+    end
     
     # just the compilation pass should suffice as a test itself
     _ = ReservedProto3.Foo.new(f1: "test")
+    _ = ReservedProto2.Foo.new(f1: "test")
   end
 
   test "can roundtrip encoding/decoding optional values in proto2" do

--- a/test/protobuf_test.exs
+++ b/test/protobuf_test.exs
@@ -1,6 +1,23 @@
 defmodule ProtobufTest do
   use Protobuf.Case
 
+  test "can handle reserved fields" do
+    defmodule ReservedProto3 do
+        use Protobuf, """
+        syntax = "proto3";
+
+        message Foo {
+            reserved 2, 15, 9 to 11;
+            reserved "foo", "bar";
+            string f1 = 1;
+        }
+        """
+    end 
+    
+    # just the compilation pass should suffice as a test itself
+    _ = ReservedProto3.Foo.new(f1: "test")
+  end
+
   test "can roundtrip encoding/decoding optional values in proto2" do
     defmodule RoundtripProto2 do
       use Protobuf, """


### PR DESCRIPTION
The current implementation mistakenly uses `reserved_numbers` tuples coming from `gpb` as `proto3_msg`, since the `name` in the tuple matches the one used in the proper `message` definition.
The commit simply skips over those tuples, since to the best of my knowledge they are useless in the generated code: those fields are by definition not mentioned in the `protobuf` message, hence they will never be either written or read.
This PR addresses bitwalker/exprotobuf#81