### PR TITLE
Allow both :optional and :defaulty as occurrence to support gpb 4.13

### DIFF
--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -149,7 +149,8 @@ defmodule Protobuf.DefineMessage do
         ast = {name, define_field_typespec(type)}
         define_trivial_typespec_fields(rest, [ast | acc])
 
-      %Protobuf.Field{name: name, occurrence: :optional, type: type} ->
+      %Protobuf.Field{name: name, occurrence: occurrence, type: type}
+      when occurrence in [:optional, :defaulty] ->
         ast =
           {name,
            quote do


### PR DESCRIPTION
gpb changed the occurence field from optional to defaulty before version
4.13 (see
https://github.com/tomas-abrahamsson/gpb/commit/a3633259d7a41e16fd2c83fab2f13d64265817f8).
This made Exprotobuf fail when compiling protobufs with gpb >= 4.13.