### PR TITLE
Run verify_msg before encoding

### DIFF
--- a/lib/exprotobuf/decoder.ex
+++ b/lib/exprotobuf/decoder.ex
@@ -1,6 +1,6 @@
 defmodule Protobuf.Decoder do
   @moduledoc false
-  use Bitwise, only_operators: true
+  import Bitwise
 
   alias Protobuf.Field
   alias Protobuf.OneOfField

--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -2,10 +2,10 @@ defmodule Protobuf.DefineMessage do
   @moduledoc false
 
   alias Protobuf.Decoder
+  alias Protobuf.Delimited
   alias Protobuf.Encoder
   alias Protobuf.Field
   alias Protobuf.OneOfField
-  alias Protobuf.Delimited
   alias Protobuf.Utils
 
   def def_message(name, fields, inject: inject, doc: doc, syntax: syntax) when is_list(fields) do
@@ -61,7 +61,7 @@ defmodule Protobuf.DefineMessage do
           unquote(constructors(name))
 
           if use_in != nil do
-            Module.eval_quoted(__MODULE__, use_in, [], __ENV__)
+            Code.eval_quoted(use_in, [], __ENV__)
           end
 
           defimpl Protobuf.Serializable do
@@ -76,7 +76,7 @@ defmodule Protobuf.DefineMessage do
 
   defp constructors(name) do
     quote location: :keep do
-      def new(), do: new([])
+      def new, do: new([])
 
       def new(values) do
         struct(unquote(name), values)

--- a/lib/exprotobuf/encoder.ex
+++ b/lib/exprotobuf/encoder.ex
@@ -28,6 +28,7 @@ defmodule Protobuf.Encoder do
     |> wrap_scalars(Utils.msg_defs(defs))
     |> fix_undefined
     |> Utils.convert_to_record(msg.__struct__)
+    |> tap(:gpb.verify_msg(&1, fixed_defs))
     |> :gpb.encode_msg(fixed_defs)
   end
 

--- a/lib/exprotobuf/encoder.ex
+++ b/lib/exprotobuf/encoder.ex
@@ -107,7 +107,7 @@ defmodule Protobuf.Encoder do
 
       %Field{type: {:msg, module}} when is_atom(module) ->
         if Utils.is_standard_scalar_wrapper(module) do
-          Map.put(module.new, :value, v)
+          Map.put(module.new(), :value, v)
         else
           do_wrap_enum(v, module, defs)
         end
@@ -118,7 +118,7 @@ defmodule Protobuf.Encoder do
     case Enum.to_list(Map.get(defs, module)) do
       [value: %Field{type: {:enum, enum_module}}] ->
         if Utils.is_enum_wrapper(module, enum_module) do
-          Map.put(module.new, :value, v)
+          Map.put(module.new(), :value, v)
         else
           v
         end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
-  "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "gpb": {:hex, :gpb, "4.5.1", "1e575446c9827d092208c433f6cfd9df41a0bcb511d1334cd02d811218362f27", [:make, :rebar], [], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm", "23f27cbc482cbac03fc8926441eb60a5e111759c17642bac005c3225f5eb809d"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm", "e3be2bc3ae67781db529b80aa7e7c49904a988596e2dbff897425b48b3581161"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "8e24fc8ff9a50b9f557ff020d6c91a03cded7e59ac3e0eec8a27e771430c7d27"},
+  "gpb": {:hex, :gpb, "4.21.1", "72e229c242d252d690addcfd04a6416c26c4d4d2c3521e05570a7a78b48d3bd1", [:make, :rebar3], [], "hexpm", "c05c9aea9e25bd341367a43b3d3eb68e951563911072259c5ec4cb6642f4ef22"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
 }

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -40,7 +40,7 @@ defmodule Protobuf.Encoder.Test do
       }
       """
   end
-  
+
   #defmodule ExtensionsProto do
     #use Protobuf, """
     #message Msg {
@@ -57,6 +57,12 @@ defmodule Protobuf.Encoder.Test do
     msg = EncoderProto.Msg.new(f1: 150)
     assert <<8, 150, 1>> == Protobuf.Serializable.serialize(msg)
     assert <<10, 3, 8, 150, 1>> == Protobuf.Serializable.serialize(EncoderProto.WithSubMsg.new(f1: msg))
+  end
+
+  test "Raises when integer is out of range" do
+    assert_raise ErlangError, fn ->
+      EncoderProto.Msg.new(f1: 2 ** 128)
+    end
   end
 
   test "fixing a nil value in repeated submsg" do


### PR DESCRIPTION
Encoding integer values of out the specified range (overflow) results in an invalid binary which crashes the decoding in a way that is very hard to troubleshoot. It's best if the encoding fails with an easy message:
```
** (ErlangError) Erlang error: {:gpb_type_error, {{:value_out_of_range, :unsigned, 32}, [value: 340282366920938463463374607431768211456, path: 'path_to_the_invalid_field']}}
```

https://github.com/tomas-abrahamsson/gpb README file states: 
> Gpb can optionally generate code for verification of values during encoding this makes it easy to catch e.g integers out of range, or values of the wrong type.
